### PR TITLE
fix(wildernessFlashEvent): Non-null assertion operator

### DIFF
--- a/source/wildernessFlashEvents.ts
+++ b/source/wildernessFlashEvents.ts
@@ -71,5 +71,5 @@ const WILDERNESS_FLASH_EVENTS_LENGTH = WILDERNESS_FLASH_EVENTS.length;
  * @returns The Wilderness Flash Event.
  */
 export function wildernessFlashEvent(offset = 0) {
-	return WILDERNESS_FLASH_EVENTS[(hoursElapsed + offset) % WILDERNESS_FLASH_EVENTS_LENGTH];
+	return WILDERNESS_FLASH_EVENTS[(hoursElapsed + offset) % WILDERNESS_FLASH_EVENTS_LENGTH]!;
 }


### PR DESCRIPTION
Adding a non-null assertion operator to this function as it cannot possibly be `null`.